### PR TITLE
New feature: `file_get_contents()` HttpClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 Thumbs.db
-/vendor
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Caching classes:
 
 ### HttpClient  (optional)
  - `ScientiaMobile\WurflCloud\HttpClient\Fsock`: Uses native PHP `fsock` calls
+ - `ScientiaMobile\WurflCloud\HttpClient\FileGetContents`: Uses native PHP `file_get_contents` calls
  - `ScientiaMobile\WurflCloud\HttpClient\Curl`: Uses the PHP extension `curl`
  - `ScientiaMobile\WurflCloud\HttpClient\Guzzle`: Uses the [Guzzle HTTP client](http://guzzlephp.org/)
 
@@ -142,7 +143,7 @@ Then make sure to use the composer autoloader `vendor/autoload.php` instead of t
 built in one (`src/sutoload.php`).
 
 #### Proxy Server Configuration
-The `Curl` and `Guzzle` HTTP Clients support a proxy server configuration via the
+The `FileGetContents`, `Curl` and `Guzzle` HTTP Clients support a proxy server configuration via the
 `setProxy()` method:
 
 ```php
@@ -202,7 +203,14 @@ tests, run `phpunit` from the root directory (where `phpunit.xml.dist`
 is located):
 
     export WURFL_CLOUD_API_KEY="123456:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    php vendor/phpunit/phpunit/phpunit.php -v
+    php vendor/bin/phpunit -v
+
+You can also use the Docker image included in `tests/docker` to run the
+test suite as follows:
+
+    cd tests/docker
+    export WURFL_CLOUD_API_KEY="123456:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    docker-compose up
 
 Note that in order to get all the tests to pass, you will need to use
 the API Key from a Premium WURFL Cloud account with all capabilities

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ Caching classes:
  - `ScientiaMobile\WurflCloud\HttpClient\Fsock`: Uses native PHP `fsock` calls
  - `ScientiaMobile\WurflCloud\HttpClient\FileGetContents`: Uses native PHP `file_get_contents` calls
  - `ScientiaMobile\WurflCloud\HttpClient\Curl`: Uses the PHP extension `curl`
- - `ScientiaMobile\WurflCloud\HttpClient\Guzzle`: Uses the [Guzzle HTTP client](http://guzzlephp.org/)
+ - `ScientiaMobile\WurflCloud\HttpClient\Guzzle`: Uses the [Guzzle HTTP client (version < 4)](http://guzzlephp.org/)
+  - `ScientiaMobile\WurflCloud\HttpClient\GuzzleHttp`: Uses the [Guzzle HTTP client (version 6+)](http://guzzlephp.org/)
 
-Note: to use `Guzzle`, you must have the Guzzle library loaded.  To load it locally,
+Note: to use `Guzzle` or `GuzzleHttp`, you must have the Guzzle library loaded.  To load it locally,
 you can run the following command from the root of the WURFL Cloud Client folder:
 
     composer update
@@ -143,7 +144,7 @@ Then make sure to use the composer autoloader `vendor/autoload.php` instead of t
 built in one (`src/sutoload.php`).
 
 #### Proxy Server Configuration
-The `FileGetContents`, `Curl` and `Guzzle` HTTP Clients support a proxy server configuration via the
+The `FileGetContents`, `Curl`, `Guzzle` and `GuzzleHttp` HTTP Clients support a proxy server configuration via the
 `setProxy()` method:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -189,6 +189,56 @@ $http_client->setTimeout(10000);
 $client = new ScientiaMobile\WurflCloud\Client($config, $cache, $http_client);
 ```
 
+### Google App Engine
+-----------------------------------------------------
+In order to use the WURFL Cloud Client in a Google App Engine PHP application, you may need to make some changes to the default configuration.
+
+First, you should use the `FileGetContents` HTTP Client since `curl` and `fsock` are not supported by default.
+
+```php
+$http_client = new ScientiaMobile\WurflCloud\HttpClient\FileGetContents();
+```
+
+Next, you should use either `Memcache` or `File` for caching:
+
+Memcache:
+```php
+$cache = new ScientiaMobile\WurflCloud\Cache\Memcache();
+```
+
+File:
+```php
+$cache = new ScientiaMobile\WurflCloud\Cache\File();
+
+// Disable UNIX hard links since they aren't supported in Google App Engine
+$cache->use_links = false;
+
+// Update this to point to your Google Cloud Storage bucket
+$cache->cache_dir = "gs://bucket_name/";
+```
+
+Putting this all together, the following is a fully functional Google App Engine config (using `Memcache`):
+
+```php
+// Create a configuration object
+$config = new ScientiaMobile\WurflCloud\Config();
+
+// Set your WURFL Cloud API Key
+$config->api_key = 'xxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+
+// Create the cache adapter
+$cache = new ScientiaMobile\WurflCloud\Cache\Memcache();
+
+// Create the HttpClient adapter
+$http_client = new ScientiaMobile\WurflCloud\HttpClient\FileGetContents();
+
+// Create the WURFL Cloud Client
+$client = new ScientiaMobile\WurflCloud\Client($config, $cache, $http_client);
+
+// Detect device
+$client->detectDevice();
+```
+
 # Unit Testing
 Unit tests are included with the client and can be run with PHPUnit.
 Before you can run the unit tests, you must install the dependencies

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
 		"php": ">=5.3.0"
 	},
 	"require-dev": {
-		"guzzle/guzzle": "~3.7@dev",
-		"phpunit/phpunit": "3.7.*"
+		"guzzle/guzzle": "3.9.*",
+		"guzzlehttp/guzzle": "6.2.*",
+		"phpunit/phpunit": "4.8.*"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/ScientiaMobile/WurflCloud/HttpClient/AbstractHttpClient.php
+++ b/src/ScientiaMobile/WurflCloud/HttpClient/AbstractHttpClient.php
@@ -127,9 +127,13 @@ abstract class AbstractHttpClient {
 	protected function processResponseHeaders($headers) {
 		$this->response_headers = explode("\r\n", $headers);
 		$this->response_http_status = $this->response_headers[0];
+
 		list($protocol, $http_status_code, $reason_code) = explode(' ', $this->response_http_status, 3);
 		$http_status_code = (int)$http_status_code;
-		if ($http_status_code >= 400 ) {
+
+		$this->success = true;
+
+		if ($http_status_code >= 400) {
 			$this->success = false;
 			switch ($http_status_code) {
 				case 401:
@@ -146,7 +150,6 @@ abstract class AbstractHttpClient {
 					break;
 			}
 		}
-		$this->success = true;
 	}
 	
 	protected function processResponseBody($body) {

--- a/src/ScientiaMobile/WurflCloud/HttpClient/FileGetContents.php
+++ b/src/ScientiaMobile/WurflCloud/HttpClient/FileGetContents.php
@@ -86,10 +86,7 @@ class FileGetContents extends Fsock {
 			$context_options['http']['proxy'] = $this->proxy;
 		}
 
-		// Merge in the overridden stream options, if any
-		$combined_options = array_replace_recursive($context_options, $this->stream_options);
-
-		$context = stream_context_create($combined_options);
+		$context = stream_context_create($context_options);
 
 		if (function_exists('error_clear_last')) {
 			// In PHP 7+ we can clear all previous errors so we're sure we capture the correct one

--- a/src/ScientiaMobile/WurflCloud/HttpClient/FileGetContents.php
+++ b/src/ScientiaMobile/WurflCloud/HttpClient/FileGetContents.php
@@ -1,0 +1,99 @@
+<?php
+namespace ScientiaMobile\WurflCloud\HttpClient;
+use ScientiaMobile\WurflCloud\Config;
+use ScientiaMobile\WurflCloud\Exception;
+/**
+ * Copyright (c) 2015 ScientiaMobile, Inc.
+ *
+ * Please refer to the COPYING.txt file distributed with the software for licensing information.
+ * 
+ * @package ScientiaMobile\WurflCloud
+ * @subpackage HttpClient
+ */
+/**
+ * An HTTP Client that uses the builtin PHP file_get_contents command
+ */
+class FileGetContents extends Fsock {
+
+	/**
+	 * Use a proxy to access the WURFL Cloud service
+	 * Proxy URL should be in the format:
+	 *   protocol://[user:pass@]ip_or_hostname:port
+	 * Ex:
+	 *   http://192.168.1.10:8080
+	 *   socks4://192.168.1.10:8080
+	 *   socks4a://192.168.1.10:8080
+	 *   socks5://myuser:mypass@192.168.1.10:8080
+	 *   
+	 * This option gets passed straight to CURL and whether or not it works
+	 * for you depends on your version of PHP/CURL.
+	 * 
+	 * @see http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY
+	 * 
+	 * @param string $proxy URL of proxy server
+	 */
+	public function setProxy($proxy) {
+		$this->proxy = $proxy;
+	}
+
+	/**
+	 * Returns the response body using the PHP cURL Extension
+	 * @param Config $config
+	 * @param string $request_path Request Path/URI
+	 * @throws HttpException Unable to query server
+	 */
+	public function call(Config $config, $request_path) {
+		$host = $config->getCloudHost();
+		
+		$url = "http://${host}${request_path}";
+
+		// Setup HTTP Request headers
+		$http_headers = array();
+		$http_headers[] = "Host: $host";
+		if ($this->use_compression === true) {
+			$http_headers[] = "Accept-Encoding: gzip";
+		}
+		$http_headers[] = "Accept: */*";
+		$http_headers[] = "Authorization: Basic ".base64_encode($config->api_key);
+		foreach ($this->request_headers as $key => $value) {
+			$http_headers[] = "$key: $value";
+		}
+		$http_headers[] = "Connection: Close";
+
+		$context_options = array(
+			'http' => array(
+				'method' => "GET",
+				'timeout' => ($this->timeout_ms / 1000),
+				'ignore_errors' => true,
+				'header' => implode("\r\n", $http_headers)."\r\n",
+			),
+		);
+
+		if ($this->proxy != '') {
+			$context_options['http']['proxy'] = $this->proxy;
+		}
+
+		$context = stream_context_create($context_options);
+
+		if (function_exists('error_clear_last')) {
+			// In PHP 7+ we can clear all previous errors so we're sure we capture the correct one
+			error_clear_last();
+		}
+
+		// Note: $http_response_header is a magic variable created by file_get_contents()
+		//  we create it here to tell code sniffers that the variable exists
+		$http_response_header = array();
+
+		// Make actual HTTP request
+		$response = @file_get_contents($url, false, $context);
+
+		if ($response === false) {
+			$error = error_get_last();
+			$error_message = $error['message'];
+			throw new HttpException("Unable to contact server: $error_message", null);
+		}
+
+		$this->processResponseHeaders(implode("\r\n", $http_response_header));
+		$this->processResponseBody($response);
+	}
+}

--- a/src/ScientiaMobile/WurflCloud/HttpClient/Fsock.php
+++ b/src/ScientiaMobile/WurflCloud/HttpClient/Fsock.php
@@ -58,7 +58,7 @@ class Fsock extends AbstractHttpClient {
 		}
 		$http_header.= "Connection: Close\r\n";
 		$http_header.= "\r\n";
-//die('<pre>'.nl2br($http_header).'</pre>');
+
 		// Setup timeout
 		stream_set_timeout($fh, 0, $this->timeout_ms * 1000);
 		

--- a/tests/ScientiaMobile/WurflCloud/HttpClient/CurlTest.php
+++ b/tests/ScientiaMobile/WurflCloud/HttpClient/CurlTest.php
@@ -13,7 +13,4 @@ class CurlTest extends HttpClientTestCase {
 		$this->http_client = new Curl();
 		parent::setUp();
 	}
-	
-	
-	
 }

--- a/tests/ScientiaMobile/WurflCloud/HttpClient/FileGetContentsTest.php
+++ b/tests/ScientiaMobile/WurflCloud/HttpClient/FileGetContentsTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ScientiaMobile\WurflCloud\HttpClient;
+
+class FileGetContentsTest extends HttpClientTestCase {
+	
+	public function setUp() {
+		$this->http_client = new FileGetContents();
+		parent::setUp();
+	}
+	
+}

--- a/tests/ScientiaMobile/WurflCloud/HttpClient/GuzzleHttpTest.php
+++ b/tests/ScientiaMobile/WurflCloud/HttpClient/GuzzleHttpTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ScientiaMobile\WurflCloud\HttpClient;
+
+class GuzzleHttpTest extends HttpClientTestCase {
+	
+	public function setUp() {
+		$this->http_client = new GuzzleHttp();
+		parent::setUp();
+	}
+
+	public function testCallNoCompression() {
+		$this->http_client->setUseCompression(false);
+		$this->http_client->call($this->config, $this->request_path);
+		$this->assertNotContains('x-encoded-content-encoding: gzip', $this->http_client->getResponseHeaders());
+	}
+	
+	public function testCallCompression() {
+		$this->http_client->setUseCompression(true);
+		$this->http_client->call($this->config, $this->request_path);
+		$this->assertContains('x-encoded-content-encoding: gzip', $this->http_client->getResponseHeaders());
+	}
+}

--- a/tests/ScientiaMobile/WurflCloud/HttpClient/GuzzleTest.php
+++ b/tests/ScientiaMobile/WurflCloud/HttpClient/GuzzleTest.php
@@ -8,9 +8,4 @@ class GuzzleTest extends HttpClientTestCase {
 		$this->http_client = new Guzzle();
 		parent::setUp();
 	}
-	
-	public function testCallTimeout() {
-		// Guzzle doesn't seem to honor timeouts consistently
-		// $this->markTestSkipped("Guzzle doesn't seem to honor timeouts consistently");
-	}
 }

--- a/tests/ScientiaMobile/WurflCloud/HttpClient/HttpClientTestCase.php
+++ b/tests/ScientiaMobile/WurflCloud/HttpClient/HttpClientTestCase.php
@@ -79,7 +79,7 @@ abstract class HttpClientTestCase extends \PHPUnit_Framework_TestCase {
 	 * @expectedExceptionMessage No API key was provided
 	 */
 	public function testCallMangledApiKey() {
-		$this->config->api_key = 'foobar';
+		$this->config->api_key = 'foo:bar';
 		$this->http_client->call($this->config, $this->request_path);
 	}
 	

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:14.04
+
+ENV TERM xterm
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y \
+        memcached \
+        php5-cli \
+        php5-curl \
+        php5-apcu \
+        php5-memcache \
+        php5-memcached \
+    && echo "apc.enable_cli=1" >> /etc/php5/mods-available/apcu.ini \
+    && php5enmod php5-apcu \
+    && php5enmod php5-memcache \
+    && php5enmod php5-memcached \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
+COPY docker-init.sh /
+VOLUME /code
+WORKDIR /code
+CMD ["/docker-init.sh"]

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,0 +1,6 @@
+php:
+    build: .
+    environment:
+        - WURFL_CLOUD_API_KEY=${WURFL_CLOUD_API_KEY}
+    volumes:
+        - ../../:/code

--- a/tests/docker/docker-init.sh
+++ b/tests/docker/docker-init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+service memcached start
+
+cd /code
+vendor/bin/phpunit -vvvv


### PR DESCRIPTION
This PR adds support for a new `HttpClient` called `FileGetContents`, which uses the PHP `file_get_contents()` command with stream wrapper support and stream context options to communicate with the central WURFL Cloud servers.