### PR TITLE
Bugfix: Disabling compression via config has no effect

### DIFF
--- a/src/ScientiaMobile/WurflCloud/Client.php
+++ b/src/ScientiaMobile/WurflCloud/Client.php
@@ -136,6 +136,10 @@ class Client {
 		$this->config = $config;
 		$this->cache = ($cache instanceof CacheInterface)? $cache: new Cookie();
 		$this->http_client = ($http_client instanceof AbstractHttpClient)? $http_client: self::getDefaultHttpClient();
+
+		if ($config->compression !== null) {
+			$this->http_client->setUseCompression($config->compression);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Disabling compression by changing `Config::compression` to `false` has no effect because it is never used to set compression on the HTTP client.

This PR changes this behavior, so `Client::__construct()` will set the compression to `Config::compression` on instantiation.  If you prefer to configure the HTTP client (and compression) manually, you can set `Config::compression` to `null`, and the HTTP client will not be touched.